### PR TITLE
add sponsor-class option

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -38,6 +38,7 @@ The shortcode [sponsors] takes the following options:
 * category (category-slug, default: all)
 * size (small|medium|large|full, default: medium)
 * style (list|grid, default: list)
+* sponsor-class (default: none)
 
 == Changelog ==
 

--- a/includes/class-wp-sponsors-shortcode.php
+++ b/includes/class-wp-sponsors-shortcode.php
@@ -18,6 +18,7 @@
             'orderby' => 'menu_order',
             'title' => 'no',
             'max' => '-1',
+            'sponsor-class' => '',
             'debug' => NULL
         ), $atts ) );
 
@@ -69,7 +70,7 @@
             case "list":
                 $style['containerPre'] = '<div id="wp-sponsors"><ul>';
                 $style['containerPost'] = '</ul></div>';
-                $style['wrapperClass'] = 'sponsor-item';
+                $style['wrapperClass'] = 'sponsor-item ';
                 $style['wrapperPre'] = 'li';
                 $style['wrapperPost'] = '</li>';
                 break;
@@ -93,6 +94,7 @@
                 $class = '';
                 $class .= $size;
                 if($debug) { $class .= ' debug'; }
+                if($atts['sponsor-class']) { $class .= ' '.$atts['sponsor-class']; }
 
                 echo '<' . $style['wrapperPre'] . ' class="' . $style['wrapperClass'] .' ' . $class . '">';
                 $sponsor = '';

--- a/includes/class-wp-sponsors-widget.php
+++ b/includes/class-wp-sponsors-widget.php
@@ -21,7 +21,8 @@
                 'pagination'             => false,
                 'order'                  => 'ASC',
                 'posts_per_page'         => '-1',
-                'orderby'                => $instance['order_by']
+                'orderby'                => $instance['order_by'],
+                'sponsor-class'          => $instance['sponsor-class']
             );
 
             if($instance['category'] != 'all' && $instance['category'] != '') {
@@ -51,7 +52,7 @@
                 <ul class="<?php echo $instance['display_option']; ?>">
                 <?php while ( $query->have_posts() ) : $query->the_post(); ?>
                     <?php $link = get_post_meta( get_the_ID(), 'wp_sponsors_url', true ); ?>
-                    <li class="sponsors-item">
+                    <li class="sponsors-item <?php echo $instance['sponsor-class']; ?>">
                         <?php if(!empty($link)) { ?>
                         <a href="<?php echo get_post_meta( get_the_ID(), 'wp_sponsors_url', true ) ?>" <?php if($instance['target_blank'] === "on"){ ?> target="_blank"<?php }; ?> <?php if($nofollow) {?>rel="nofollow" <?php } ?>>
                         <?php }; ?>
@@ -86,6 +87,7 @@
             $instance['display_option'] = $new_instance['display_option'];
             $instance['title'] = strip_tags( $new_instance['title'] );
             $instance['max'] = $new_instance['max'];
+            $instance['sponsor-class'] = $new_instance['sponsor-class'];
             return $instance;
         }
 
@@ -135,6 +137,10 @@
             <p>
                 <label for="<?php echo $this->get_field_id( 'max' ); ?>"><?php _e('Number of sponsors to show  (leave to show all)', 'wp-sponsors'); ?></label>
                 <input id="<?php echo $this->get_field_id( 'max' ); ?>" name="<?php echo $this->get_field_name( 'max' ); ?>" value="<?php echo $instance['max']; ?>" style="width:100%;"  type="number"/>
+            </p>
+            <p>
+                <label for="<?php echo $this->get_field_id( 'sponsor-class' ); ?>"><?php _e('Class applied to each sponsor', 'wp-sponsors'); ?></label>
+                <input id="<?php echo $this->get_field_id( 'sponsor-class' ); ?>" name="<?php echo $this->get_field_name( 'sponsor-class' ); ?>" value="<?php echo $instance['sponsor-class']; ?>" style="width:100%;"/>
             </p>
             <p>
                 <input type="checkbox" id="<?php echo $this->get_field_id('show_title'); ?>" name="<?php echo $this->get_field_name('show_title'); ?>" <?php checked($instance['show_title'], 'on'); ?> />

--- a/languages/wp-sponsors-fr_BE.po
+++ b/languages/wp-sponsors-fr_BE.po
@@ -201,3 +201,6 @@ msgstr "Studio Espresso"
 
 #~ msgid "Sponsor Logo"
 #~ msgstr "Sponsor Logo"
+
+msgid "Class applied to each sponsor"
+msgstr "Classe ajoutée à chaque sponsor"

--- a/languages/wp-sponsors-nl_BE.po
+++ b/languages/wp-sponsors-nl_BE.po
@@ -201,3 +201,6 @@ msgstr "Studio Espresso"
 
 #~ msgid "Sponsor Logo"
 #~ msgstr "Sponsor Logo"
+
+msgid "Class applied to each sponsor"
+msgstr "Class toegevoed aan elk sponsor"

--- a/languages/wp-sponsors-nl_NL.po
+++ b/languages/wp-sponsors-nl_NL.po
@@ -201,3 +201,6 @@ msgstr "Studio Espresso"
 
 #~ msgid "Sponsor Logo"
 #~ msgstr "Sponsor Logo"
+
+msgid "Class applied to each sponsor"
+msgstr "Class toegevoed aan elk sponsor"


### PR DESCRIPTION
Allow extra class to be applied to each sponsor container
Possible use case: 'col-xs-6 col-md-12 col-lg-6' will fit 1 or 2 sponsors in a theme based on a bootstrap grid.